### PR TITLE
Reduced the log level for gippyLib to omit chunk rw messages.

### DIFF
--- a/bfalg_ndwi/ndwi.py
+++ b/bfalg_ndwi/ndwi.py
@@ -330,7 +330,7 @@ def getImageSize(filenames):
 def cli():
     args = parse_args(sys.argv[1:])
     logger.setLevel(args.verbose * 10)
-    gippy.Options.set_verbose(5)
+    gippy.Options.set_verbose(3)
     gippy.Options.set_chunksize(args.chunksize)
     outdir = validate_outdir(args.outdir)
     bname = validate_basename(args.basename)


### PR DESCRIPTION
Log levels above 3, gippy will log stats for every chunk read/write. For anything other than huge chunks  this can be a lot of messages. 